### PR TITLE
Response Header and Cookie exists check

### DIFF
--- a/lib/support/chrome-perflog-parser.js
+++ b/lib/support/chrome-perflog-parser.js
@@ -312,9 +312,10 @@ function populateEntryFromResponse(entry, response, timestamp) {
     } else {
       entry.request.headersSize = calculateRequestHeaderSize(entry.request);
     }
-
-    const cookieHeader = response.requestHeaders.Cookie || '';
-    entry.request.cookies = parseCookies(cookieHeader.split(';'));
+    if(response.hasOwnProperty('requestHeaders') && response.requestHeaders.hasOwnProperty('Cookie')) {
+      const cookieHeader = response.requestHeaders.Cookie || '';
+      entry.request.cookies = parseCookies(cookieHeader.split(';'));
+    }
   }
 
   let blocked = response.timing["dnsStart"];


### PR DESCRIPTION
Wrapping response cookie entries in check to make sure they exist before parsing. This revealed another issue with multiple runs of a decent size site as JSON.stringify on the generating of the har file fails due to the object being too large to work out of memory. I can look into that separately. 



 