### PR TITLE
Surfacing connection id for chrome - useful for debugging

### DIFF
--- a/lib/support/chrome-perflog-parser.js
+++ b/lib/support/chrome-perflog-parser.js
@@ -366,6 +366,8 @@ function populateEntryFromResponse(entry, response, timestamp) {
 
   entry.time = (timestamp - response.timing.requestTime) * 1000;
 
+  entry.connection = response.connectionId.toString()
+
 }
 
 function parseCookies(cookieStrings) {


### PR DESCRIPTION
Useful for debugging parallel/delayed requests and connections that are reused. Unfortunately it appears the current Firefox(version 44) uses the port for the connection id which isn't as useful.