### PR TITLE
Use previous connection id's time as blocking time

### DIFF
--- a/lib/core/webdriver_builder.js
+++ b/lib/core/webdriver_builder.js
@@ -13,7 +13,14 @@ let Promise = require('bluebird'),
 
 let hasConfiguredChromeDriverService = false;
 let hasConfiguredIEDriverPath = false;
-const defaultChromeOptions = ['--disable-plugins-discovery',
+const defaultChromeOptions = [
+  // disable caching
+  '--disable-cache',
+  '--disk-cache-size=0',
+  '--disable-local-storage',
+  '--disable-application-cache',
+
+  '--disable-plugins-discovery',
   '--disable-bundled-ppapi-flash',
   '--enable-experimental-extension-apis',
   '--disable-background-networking',
@@ -87,8 +94,6 @@ const defaultFirefoxPreferences = {
   'signon.rememberSignons': false,
   'javascript.options.showInConsole': true,
   'xpinstall.signatures.required': false
-  // 'devtools.chrome.enabled': true,
-  // 'devtools.debugger.remote-enabled': true
 };
 
 /**

--- a/lib/support/chrome-perflog-parser.js
+++ b/lib/support/chrome-perflog-parser.js
@@ -438,9 +438,7 @@ function populateEntryFromResponse(entry, previousConnectionIds, entries, respon
 
     entry.time = dns + connect + send + wait + receive;
 
-    console.log(entry.connection);
     let previousConnectionRequestId = previousConnectionIds.get(entry.connection)
-    console.log(previousConnectionRequestId);
     if(response.connectionReused && (entry._frameId !== entry._requestId) && previousConnectionRequestId) {
       let previousEntry = entries.find((entry) => entry._requestId === previousConnectionRequestId);
       entry.timings.blocked += previousEntry.time;

--- a/lib/support/chrome-perflog-parser.js
+++ b/lib/support/chrome-perflog-parser.js
@@ -22,6 +22,7 @@ module.exports = {
       entries = [],
       currentPageId,
       ongoingDataRequests = new Set(),
+      previousConnectionIds = new Map(),
       rootFrameMappings = new Map();
 
     for (let event of events) {
@@ -84,6 +85,7 @@ module.exports = {
           let entry = {
             cache: {},
             startedDateTime: moment.unix(data.wallTime).toISOString(), //epoch float64, eg 1440589909.59248
+            _requestWillBeSentTime: data.timestamp,
             _wallTime: data.wallTime,
             _requestId: data.requestId,
             _frameId: data.frameId,
@@ -95,7 +97,7 @@ module.exports = {
           if (data.redirectResponse) {
             let previousEntry = entries.find((entry) => entry._requestId === data.requestId);
             previousEntry._requestId = previousEntry._requestId + 'r';
-            populateEntryFromResponse(previousEntry, data.redirectResponse, data.timestamp);
+            populateEntryFromResponse(previousEntry, previousConnectionIds, entries, data.redirectResponse, data.timestamp);
             previousEntry.response.redirectURL = request.url;
           }
 
@@ -127,9 +129,11 @@ module.exports = {
             log.warn('Recieved network response for requestId ' + data.requestId + ' with no matching request.');
             continue;
           }
+          entry._responseReceivedTime = data.timestamp;
+          entry._totalRequestTime = (data.timestamp - entry._requestWillBeSentTime) * 1000;
 
           try {
-            populateEntryFromResponse(entry, data.response, data.timestamp);
+            populateEntryFromResponse(entry, previousConnectionIds, entries, data.response, data.timestamp);
           } catch (e) {
             log.error('Error parsing response: ' + JSON.stringify(data, null, 2));
             throw e;
@@ -153,6 +157,8 @@ module.exports = {
             continue;
           }
 
+          entry._dataReceivedTime = entry.timestamp;
+
           entry.response.content.size += data.dataLength;
         }
           break;
@@ -174,6 +180,7 @@ module.exports = {
             continue;
           }
 
+          entry._loadingFinishedTime = data.timestamp;
           entry.response.bodySize = entry.response.content.size;
           //if (entry.response.headersSize > -1) {
           //  entry.response.bodySize -= entry.response.headersSize;
@@ -190,8 +197,6 @@ module.exports = {
               entry.response.content.compression = compression;
             }
           }
-          entry.time = (data.timestamp - entry.request._timestamp) * 1000;
-          //entry.timings.receive = (entry.timings.receive + data.timestamp*1000);
         }
           break;
 
@@ -297,6 +302,12 @@ module.exports = {
       }
     }
 
+    entries.sort((a,b) => {
+      if(parseFloat(a) > parseFloat(b)) return -1;
+      if(parseFloat(a) < parseFloat(b)) return 1;
+      return 0;
+    });
+
     entries = entries.filter((entry) => {
       // Page doesn't wait for favicon to load, and that's ok (for now).
       if (!entry.response && !entry.request.url.endsWith('.ico')) {
@@ -338,7 +349,7 @@ function calculateResponseHeaderSize(perflogResponse) {
   return buffer.length;
 }
 
-function populateEntryFromResponse(entry, response, timestamp) {
+function populateEntryFromResponse(entry, previousConnectionIds, entries, response, timestamp) {
   entry.response = {
     httpVersion: response.protocol,
     redirectURL: '',
@@ -382,6 +393,9 @@ function populateEntryFromResponse(entry, response, timestamp) {
     }
   }
 
+  entry.connection = response.connectionId.toString();
+  entry._connectionReused = response.connectionReused;
+
   if (response.timing) {
     let blocked = response.timing["dnsStart"];
     if (blocked < 0.0) {
@@ -408,45 +422,72 @@ function populateEntryFromResponse(entry, response, timestamp) {
       ssl = 0.0
     }
 
+    let receive = timestamp - response.timing["requestTime"];
+
     entry.timings = {
       blocked,
       dns,
       connect,
       send,
       wait,
-      receive: timestamp - response.timing["requestTime"],
+      receive,
       ssl
     };
 
-    entry._requestTime = response.timing["requestTime"];
+    entry._requestSentTime = response.timing["requestTime"];
 
-    entry.time = (timestamp - response.timing.requestTime) * 1000;
+    entry.time = dns + connect + send + wait + receive;
+
+    console.log(entry.connection);
+    let previousConnectionRequestId = previousConnectionIds.get(entry.connection)
+    console.log(previousConnectionRequestId);
+    if(response.connectionReused && (entry._frameId !== entry._requestId) && previousConnectionRequestId) {
+      let previousEntry = entries.find((entry) => entry._requestId === previousConnectionRequestId);
+      entry.timings.blocked += previousEntry.time;
+
+      let blockedTimeCheck = entry.timings.blocked / 1000;
+      if((entry._requestWillBeSentTime - blockedTimeCheck) > previousEntry._requestWillBeSentTime) {
+        entry.timings.blocked = blocked;
+      }
+    }
+
+    entry.time += entry.timings.blocked;
+
   } else {
     entry.timings = {
+      blocked: 0,
+      dns: 0,
+      connect: 0,
       send: 0,
       wait: 0,
       receive: 0,
+      ssl: 0,
       comment: 'No timings available from Chrome'
     };
     entry.time = 0;
   }
 
-  entry.connection = response.connectionId.toString()
-
+  previousConnectionIds.set(entry.connection, entry._requestId);
 }
 
 function parseCookies(cookieStrings) {
   return cookieStrings.filter(Boolean).map((cookieString) => {
-    let cookie = Cookie.parse(cookieString);
-    return {
-      'name': cookie.key,
-      'value': cookie.value,
-      'path': cookie.path || undefined, // must be undefined, not null, to exclude empty path
-      'domain': cookie.domain || undefined,  // must be undefined, not null, to exclude empty domain
-      'expires': cookie.expires === 'Infinity' ? undefined : moment(cookie.expires).toISOString(),
-      'httpOnly': cookie.httpOnly,
-      'secure': cookie.secure
-    };
+      let cookie = Cookie.parse(cookieString);
+      if(!cookie) {
+        log.warn("Invalid cookie - failed to parse value: " + cookieString);
+
+        return null;
+      }
+
+      return {
+        'name': cookie.key,
+        'value': cookie.value,
+        'path': cookie.path || undefined, // must be undefined, not null, to exclude empty path
+        'domain': cookie.domain || undefined,  // must be undefined, not null, to exclude empty domain
+        'expires': cookie.expires === 'Infinity' ? undefined : moment(cookie.expires).toISOString(),
+        'httpOnly': cookie.httpOnly,
+        'secure': cookie.secure
+      };
   });
 }
 

--- a/lib/support/chrome-perflog-parser.js
+++ b/lib/support/chrome-perflog-parser.js
@@ -439,7 +439,7 @@ function populateEntryFromResponse(entry, previousConnectionIds, entries, respon
     entry.time = dns + connect + send + wait + receive;
 
     let previousConnectionRequestId = previousConnectionIds.get(entry.connection)
-    if(response.connectionReused && (entry._frameId !== entry._requestId) && previousConnectionRequestId) {
+    if(response.connectionReused && previousConnectionRequestId) {
       let previousEntry = entries.find((entry) => entry._requestId === previousConnectionRequestId);
       entry.timings.blocked += previousEntry.time;
 

--- a/lib/support/chrome-perflog-parser.js
+++ b/lib/support/chrome-perflog-parser.js
@@ -303,8 +303,8 @@ module.exports = {
     }
 
     entries.sort((a,b) => {
-      if(parseFloat(a) > parseFloat(b)) return -1;
-      if(parseFloat(a) < parseFloat(b)) return 1;
+      if(parseFloat(a.requestId) > parseFloat(b.requestId)) return -1;
+      if(parseFloat(a.requstId) < parseFloat(b.requestId)) return 1;
       return 0;
     });
 


### PR DESCRIPTION
@tobli / @soulgalore for #102 It's ugly and needs some clean up, but should work. 

*Note since Chrome has "Stalled" and "Queued"  and and they do not surface either in the logs I had no choice but to report both as "blocking". In Chrome's Dev Tools "stalled" actually pushes the start time out and "queued" actually reports as blocking time for the next request on the shared connection id. IMO  adding to "blocking" time for both makes more sense to me since if they are sharing connection ids they can't do anything until the previous request is complete in HTTP/1. It more clearly shows performance bottlenecks with having too many requests going to a single domain