### PR TITLE
Remove entry sorting method for chrome native har builder

### DIFF
--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -402,20 +402,6 @@ module.exports = {
       }
     }
 
-    entries.sort(function(firstEntry, secondEntry) {
-      const firstId = firstEntry._requestId.replace(/r$/, ''),
-        secondId = secondEntry._requestId.replace(/r$/, '');
-
-      let sortOrder = firstId.localeCompare(secondId, undefined, {numeric: true});
-
-      if (sortOrder === 0) {
-        // reverse order to make requestIds ending with 'r' sort first
-        sortOrder = secondEntry._requestId.localeCompare(firstEntry._requestId);
-      }
-
-      return sortOrder;
-    });
-
     entries = entries.filter((entry) => {
       // Page doesn't wait for favicon to load, and that's ok (for now).
       if (!entry.response && !entry.request.url.endsWith('.ico')) {


### PR DESCRIPTION
Confirmed sorting isn't needed as the waterfalls are displayed using startDateTime which is incorrect. The items should not be sorted by requestId since the numbers aren't sequentially received due to the 6 or so parallel connections with HTTP/1.1 and would be worse with HTTP/2. Redirects can also cause the requestIds to be out of order since the final request can come after newer requestId that didn't have a redirect.