### PR TITLE
Fixing blocked time calculations and removing hack for previous calcuations of blocked time

### DIFF
--- a/lib/support/chromePerflogParser.js
+++ b/lib/support/chromePerflogParser.js
@@ -72,7 +72,7 @@ module.exports = {
 
       let timing = response.timing;
       if (timing) {
-        let blocked = firstNonNegative(timing["dnsStart"], timing["connectStart"], timing["sendStart"]);
+        let blocked = firstNonNegative([timing["dnsStart"], timing["connectStart"], timing["sendStart"]]);
 
         let dns = -1;
         if (timing["dnsStart"] >= 0) {
@@ -106,14 +106,15 @@ module.exports = {
         const max = Math.max;
         entry.time = max(0, blocked) + max(0, dns) + max(0, connect) + send + wait + receive;
 
-        //TODO: figure out how to correctly calculate blocking time
-        let previousConnectionRequestId = previousConnectionIds.get(entry.connection);
+        //TODO: figure out how to correctly calculate startedDateTime for connections reused
+        
+        /*let previousConnectionRequestId = previousConnectionIds.get(entry.connection);
         if (response.connectionReused && previousConnectionRequestId) {
           let previousEntry = entries.find((entry) => entry._requestId === previousConnectionRequestId);
           if (((entry._requestWillBeSentTime - previousEntry._requestWillBeSentTime) * 1000) < previousEntry.time) {
             entry.timings.blocked = previousEntry.time;
           }
-        }
+        }*/
 
         entry.time += entry.timings.blocked;
 


### PR DESCRIPTION
Fixed incorrectly passed argument to firstNonNegative  method and removed previous hack for using unaccounted time as blocking. 

TODO: investigate the remaining unaccounted time for connections reused. 