### PR TITLE
Fixing options to allow overriding filename for .json and .har output files

### DIFF
--- a/bin/browsertime.js
+++ b/bin/browsertime.js
@@ -80,13 +80,14 @@ function run(url, options) {
       let saveOperations = [];
 
       const storageManager = new StorageManager(url, options);
-
+      const harName = (options.har) ? (options.har) : 'browsertime';
+      const jsonName = (options.output) ? (options.output) : 'browsertime';
       const btData = pick(result, ['info', 'browserScripts', 'statistics', 'visualMetrics']);
       if (!util.isEmpty(btData)) {
-        saveOperations.push(storageManager.writeJson('browsertime.json', btData));
+        saveOperations.push(storageManager.writeJson(jsonName + '.json', btData));
       }
       if (result.har) {
-        saveOperations.push(storageManager.writeJson('browsertime.har', result.har));
+        saveOperations.push(storageManager.writeJson(harName + '.har', result.har));
       }
       forEach(result.extras, (value, key) =>
         saveOperations.push(storageManager.writeData(key, value)));

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -61,6 +61,7 @@ module.exports.parseCommandLine = function parseCommandLine() {
     .default('browser','chrome')
     .boolean('experimental.dumpChromePerflog')
     .boolean('experimental.video')
+    .string('har')
     .string('userAgent')
     .string('seleniumUrl')
     .string('preTask')
@@ -123,8 +124,8 @@ module.exports.parseCommandLine = function parseCommandLine() {
       'On OS X, the path should be to the binary inside the app bundle, ' +
       'e.g. /Applications/Firefox.app/Contents/MacOS/firefox-bin')
     .describe('silent', 'Only output info in the logs, not to the console')
-    .describe('output', 'Specify file name for Browsertime data. Unless specified, file will be named <domain>-<timestamp>.json')
-    .describe('har', 'Specify file name for .har file. Unless specified, file will be named <domain>-<timestamp>.har')
+    .describe('output', 'Specify file name for Browsertime data (ex: \'browsertime\'). Unless specified, file will be named browsertime.json')
+    .describe('har', 'Specify file name for .har file (ex: \'browsertime\'). Unless specified, file will be named browsertime.har')
     .describe('skipHar', 'Pass --skipHar to not collect a HAR file.')
     .describe('seleniumServer', 'Use SeleniumServer jar file to interact with browser.')
     .describe('seleniumUrl', 'URL to a running Selenium server (e.g. to run a browser on another machine).')


### PR DESCRIPTION
Wasn't sure if we needed a test for this since it's mostly just a pass through of the option if set, so not much magic going on. :-) Let me know if we want one and I'll try to add it tomorrow.