### PR TITLE
Hide status bar in Firefox to get valid speedindex

### DIFF
--- a/browsersupport/firefox-profile/chrome/userChrome.css
+++ b/browsersupport/firefox-profile/chrome/userChrome.css
@@ -1,0 +1,4 @@
+@namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"); /* only needed once */
+
+/* use this code to hide all messages */
+statuspanel { display:none!important; }

--- a/lib/core/webdriverBuilder.js
+++ b/lib/core/webdriverBuilder.js
@@ -181,9 +181,9 @@ module.exports.createWebDriver = function(options) {
     }
       break;
 
-    case 'firefox':
-    {
-      let profile = new firefox.Profile();
+    case 'firefox': {
+      const profileTemplatePath = path.resolve(__dirname, '..', '..', 'browsersupport', 'firefox-profile'),
+        profile = new firefox.Profile(profileTemplatePath);
 
       if (options.userAgent) {
         profile.setPreference('general.useragent.override', options.userAgent);


### PR DESCRIPTION
When recording a video for SpeedIndex visualmetrics picks up on the small loading indicator in the lower left corner of the Firefox window. Use a custom user stylesheet to hide it, to fix incorrect SpeedIndex calculation.