### PR TITLE
Adding device option to connectivity for browsertime

### DIFF
--- a/lib/core/engine.js
+++ b/lib/core/engine.js
@@ -53,7 +53,7 @@ class Engine {
   }
 
   start() {
-    if (this.options.connection !== 'native') {
+    if (this.options.connectivity &&  this.options.connectivity.profile !== 'native') {
       connectivity.set(this.options);
     }
     return this.runDelegate.onStart();
@@ -277,8 +277,8 @@ class Engine {
   }
 
   stop() {
-    if (this.options.connection !== 'native' && this.options.connection !== undefined) {
-      connectivity.remove();
+    if (this.options.connectivity && this.options.connectivity.profile !== 'native' && this.options.connectivity.profile !== undefined) {
+      connectivity.remove(this.options);
     }
     return this.runDelegate.onStop();
   }

--- a/lib/support/cli.js
+++ b/lib/support/cli.js
@@ -29,7 +29,7 @@ function validateInput(argv) {
      }
    }
 
-   if (argv.connectivity !== 'native') {
+   if (argv.connectivity.profile !== 'native') {
      if (!hasbin.all.sync(['tc', 'modprobe', 'ip'])) {
        return 'You need to have tc, modprobe and ip in your path to be able to set the connectivity.'
      }
@@ -172,10 +172,14 @@ module.exports.parseCommandLine = function parseCommandLine() {
       default: 0,
       describe: 'Delay between runs, in milliseconds'
     })
-    .option('connectivity', {
+    .option('connectivity.profile', {
       default: 'native',
       choices: ['mobile3g', 'mobile3gfast', 'mobile3gslow', 'mobile2g', 'cable', 'native'],
       describe: 'The connectivity profile. Need TC to work'
+    })
+    .option('connectivity.device', {
+      default: 'eth0',
+      describe: 'The connectivity device. Need TC to work'
     })
     .option('preScript', {
       describe: 'Task(s) to run before you test your URL (use it for login etc). Note that --preScript can be passed multiple times.'

--- a/lib/support/connectivity.js
+++ b/lib/support/connectivity.js
@@ -8,7 +8,7 @@ module.exports = {
         const profile = trafficShapeParser.parseTrafficShapeConfig(options);
         if (profile !== null) {
             sltc({
-                device: 'eth0',
+                device: options.connectivity.device,
                 bandwith: {
                     download: profile.downstreamKbps + 'kbps',
                     upload: profile.upstreamKbps + 'kbps'
@@ -18,8 +18,9 @@ module.exports = {
             });
         }
     },
-    remove: function() {
-        sltc({
+    remove: function(options) {
+      sltc({
+            device: options.connectivity.device,
             remove: true
         });
     }

--- a/lib/support/trafficShapeParser.js
+++ b/lib/support/trafficShapeParser.js
@@ -31,14 +31,14 @@ const profiles = {
 module.exports = {
   parseTrafficShapeConfig: function(options) {
 
-    if (options.connectivity) {
-      if (options.connectivity === 'native') {
+    if (options.connectivity && options.connectivity.profile) {
+      if (options.connectivity.profile === 'native') {
         return null;
       }
 
-      let profile = profiles[options.connectivity];
+      let profile = profiles[options.connectivity.profile];
       if (!profile) {
-        throw new Error(`Unknown connectivity profile ${options.connectivity}`);
+        throw new Error(`Unknown connectivity profile ${options.connectivity.profile}`);
       }
       return profile;
     } else {

--- a/test/trafficShapeParserTests.js
+++ b/test/trafficShapeParserTests.js
@@ -27,7 +27,7 @@ describe('traffic_shape_parser', function() {
 
       it('should return profile for ' + name, function() {
         let shapeConfig = parser.parseTrafficShapeConfig({
-          connectivity: name
+          connectivity: {profile: name}
         });
         shapeConfig.should.deep.equal(profile);
       });
@@ -35,7 +35,7 @@ describe('traffic_shape_parser', function() {
 
     it('should return null for "native" traffic shape config', function() {
       let shapeConfig = parser.parseTrafficShapeConfig({
-        connection: 'native'
+        connection: {profile: 'native'}
       });
       expect(shapeConfig).to.equal(null);
     });


### PR DESCRIPTION
Unrelated to our other work of getting this to work in docker. This allows the user to override the device for the connection throttling if it isn't the default eth0 device.